### PR TITLE
Feat: Talent Readiness Analytics Feature

### DIFF
--- a/src/main/java/com/capstone/controller/TalentReadinessController.java
+++ b/src/main/java/com/capstone/controller/TalentReadinessController.java
@@ -1,0 +1,151 @@
+package com.capstone.controller;
+
+import com.capstone.dto.response.*;
+import com.capstone.model.ReadinessLevel;
+import com.capstone.service.TalentReadinessService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/analytics/talent-readiness")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Talent Readiness Analytics", description = "APIs for talent readiness assessment and reporting")
+public class TalentReadinessController {
+
+    private final TalentReadinessService talentReadinessService;
+
+    @GetMapping
+    @Operation(
+            summary = "Get all talent readiness (no filters)",
+            description = "Retrieve paginated list of all learners with their readiness metrics"
+    )
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentReadinessDto>>> getAllTalentReadiness(
+            @PageableDefault(sort = "learner.username") Pageable pageable) {
+
+        log.info("GET /api/v1/analytics/talent-readiness - All learners, page: {}", pageable.getPageNumber());
+
+        PaginatedResponseDto<TalentReadinessDto> response = talentReadinessService.getAllTalentReadiness(pageable);
+
+        return ResponseEntity.ok(ApiResponseDto.success(response, "Talent readiness list retrieved successfully"));
+    }
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "Search talent readiness by keyword",
+            description = "Search learners by username, email, or talent route name"
+    )
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentReadinessDto>>> searchTalentReadiness(
+            @Parameter(description = "Search keyword for username, email, or route name")
+            @RequestParam String keyword,
+            @PageableDefault(sort = "learner.username") Pageable pageable) {
+
+        log.info("GET /api/v1/analytics/talent-readiness/search - keyword: {}, page: {}", keyword, pageable.getPageNumber());
+
+        PaginatedResponseDto<TalentReadinessDto> response = talentReadinessService.searchTalentReadiness(keyword, pageable);
+
+        return ResponseEntity.ok(ApiResponseDto.success(response, "Search results retrieved successfully"));
+    }
+
+    @GetMapping("/by-talent-route/{talentRouteId}")
+    @Operation(
+            summary = "Filter by talent route",
+            description = "Get learners enrolled in a specific talent route"
+    )
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentReadinessDto>>> getByTalentRoute(
+            @Parameter(description = "Talent route ID")
+            @PathVariable UUID talentRouteId,
+            @PageableDefault(sort = "learner.username") Pageable pageable) {
+
+        log.info("GET /api/v1/analytics/talent-readiness/by-talent-route/{} - page: {}", talentRouteId, pageable.getPageNumber());
+
+        PaginatedResponseDto<TalentReadinessDto> response = talentReadinessService.getByTalentRoute(talentRouteId, pageable);
+
+        return ResponseEntity.ok(ApiResponseDto.success(response, "Talent readiness by route retrieved successfully"));
+    }
+
+    @GetMapping("/by-readiness-level/{readinessLevel}")
+    @Operation(
+            summary = "Filter by readiness level",
+            description = "Get learners with specific readiness level (NOT_READY, MEDIUM, HIGH)"
+    )
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentReadinessDto>>> getByReadinessLevel(
+            @Parameter(description = "Readiness level: NOT_READY, MEDIUM, or HIGH")
+            @PathVariable ReadinessLevel readinessLevel,
+            @PageableDefault(sort = "learner.username") Pageable pageable) {
+
+        log.info("GET /api/v1/analytics/talent-readiness/by-readiness-level/{} - page: {}", readinessLevel, pageable.getPageNumber());
+
+        PaginatedResponseDto<TalentReadinessDto> response = talentReadinessService.getByReadinessLevel(readinessLevel, pageable);
+
+        return ResponseEntity.ok(ApiResponseDto.success(response, "Talent readiness by level retrieved successfully"));
+    }
+
+    @PostMapping("/by-clusters")
+    @Operation(
+            summary = "Filter by clusters/skills",
+            description = "Get learners who have completed capsules tagged with specified clusters (skills)"
+    )
+    public ResponseEntity<ApiResponseDto<PaginatedResponseDto<TalentReadinessDto>>> getByClusters(
+            @Parameter(description = "Cluster filter request with cluster IDs")
+            @RequestBody ClusterFilterRequest request,
+            @PageableDefault(sort = "learner.username") Pageable pageable) {
+
+        log.info("POST /api/v1/analytics/talent-readiness/by-clusters - clusterIds: {}, page: {}",
+                request.getClusterIds(), pageable.getPageNumber());
+
+        PaginatedResponseDto<TalentReadinessDto> response = talentReadinessService.getByClusters(
+                request.getClusterIds(), pageable);
+
+        return ResponseEntity.ok(ApiResponseDto.success(response, "Talent readiness by clusters retrieved successfully"));
+    }
+
+    @GetMapping("/clusters")
+    @Operation(
+            summary = "Get available clusters",
+            description = "Retrieve all unique clusters/skills available in the system for filtering purposes"
+    )
+    public ResponseEntity<ApiResponseDto<List<ClusterDto>>> getAvailableClusters() {
+        log.info("GET /api/v1/analytics/talent-readiness/clusters");
+
+        List<ClusterDto> clusters = talentReadinessService.getAvailableClusters();
+
+        return ResponseEntity.ok(ApiResponseDto.success(clusters, "Available clusters retrieved successfully"));
+    }
+
+    @GetMapping("/talent-routes")
+    @Operation(
+            summary = "Get available talent routes",
+            description = "Retrieve all talent routes that have enrolled learners for dropdown population"
+    )
+    public ResponseEntity<ApiResponseDto<List<TalentRouteDto>>> getAvailableTalentRoutes() {
+        log.info("GET /api/v1/analytics/talent-readiness/talent-routes");
+
+        List<TalentRouteDto> routes = talentReadinessService.getAvailableTalentRoutes();
+
+        return ResponseEntity.ok(ApiResponseDto.success(routes, "Available talent routes retrieved successfully"));
+    }
+
+    @GetMapping("/heatmap")
+    @Operation(
+            summary = "Get role readiness heatmap",
+            description = "Retrieve aggregated readiness statistics grouped by talent routes for heatmap visualization"
+    )
+    public ResponseEntity<ApiResponseDto<RoleReadinessHeatmapDto>> getRoleReadinessHeatmap() {
+        log.info("GET /api/v1/analytics/talent-readiness/heatmap");
+
+        RoleReadinessHeatmapDto heatmap = talentReadinessService.getRoleReadinessHeatmap();
+
+        return ResponseEntity.ok(ApiResponseDto.success(heatmap, "Role readiness heatmap retrieved successfully"));
+    }
+}

--- a/src/main/java/com/capstone/controller/TalentReadinessController.java
+++ b/src/main/java/com/capstone/controller/TalentReadinessController.java
@@ -1,5 +1,6 @@
 package com.capstone.controller;
 
+import com.capstone.dto.request.ClusterFilterRequest;
 import com.capstone.dto.response.*;
 import com.capstone.model.ReadinessLevel;
 import com.capstone.service.TalentReadinessService;

--- a/src/main/java/com/capstone/dto/request/ClusterFilterRequest.java
+++ b/src/main/java/com/capstone/dto/request/ClusterFilterRequest.java
@@ -1,4 +1,4 @@
-package com.capstone.dto.response;
+package com.capstone.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/capstone/dto/request/ClusterFilterRequest.java
+++ b/src/main/java/com/capstone/dto/request/ClusterFilterRequest.java
@@ -1,0 +1,15 @@
+package com.capstone.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClusterFilterRequest {
+    private List<UUID> clusterIds;
+}

--- a/src/main/java/com/capstone/dto/response/ClusterDto.java
+++ b/src/main/java/com/capstone/dto/response/ClusterDto.java
@@ -1,0 +1,17 @@
+package com.capstone.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClusterDto {
+    private UUID clusterId;
+    private String clusterName;
+}

--- a/src/main/java/com/capstone/dto/response/ReadinessBreakdownDto.java
+++ b/src/main/java/com/capstone/dto/response/ReadinessBreakdownDto.java
@@ -1,0 +1,16 @@
+package com.capstone.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadinessBreakdownDto {
+    private Integer notReady;
+    private Integer medium;
+    private Integer high;
+}

--- a/src/main/java/com/capstone/dto/response/RoleReadinessDto.java
+++ b/src/main/java/com/capstone/dto/response/RoleReadinessDto.java
@@ -1,0 +1,20 @@
+package com.capstone.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleReadinessDto {
+    private UUID talentRouteId;
+    private String talentRouteName;
+    private Integer learnersCount;
+    private Double averageAssessmentScore;
+    private ReadinessBreakdownDto readinessBreakdown;
+}

--- a/src/main/java/com/capstone/dto/response/RoleReadinessHeatmapDto.java
+++ b/src/main/java/com/capstone/dto/response/RoleReadinessHeatmapDto.java
@@ -1,0 +1,16 @@
+package com.capstone.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoleReadinessHeatmapDto {
+    private List<RoleReadinessDto> talentRoutes;
+}

--- a/src/main/java/com/capstone/dto/response/TalentReadinessDto.java
+++ b/src/main/java/com/capstone/dto/response/TalentReadinessDto.java
@@ -1,0 +1,38 @@
+package com.capstone.dto.response;
+
+import com.capstone.model.ReadinessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TalentReadinessDto {
+    private UUID learnerId;
+    private String learnerName;
+    private String learnerEmail;
+
+    private UUID talentRouteId;
+    private String talentRouteName;
+
+    private UUID growthTrackId;
+    private String growthTrackName;
+
+    private Double assessmentAverage;
+
+    private Integer skillsCompleted;
+    private Integer skillsTotal;
+    private String skillsProgress;
+    private Double skillsProgressPercentage;
+
+    private List<ClusterDto> clusters;
+
+    private ReadinessLevel readinessLevel;
+    private Double readinessScore;
+}

--- a/src/main/java/com/capstone/dto/response/TalentRouteDto.java
+++ b/src/main/java/com/capstone/dto/response/TalentRouteDto.java
@@ -1,0 +1,17 @@
+package com.capstone.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TalentRouteDto {
+    private UUID talentRouteId;
+    private String routeName;
+}

--- a/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/capstone/exception/GlobalExceptionHandler.java
@@ -54,5 +54,33 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponseDto.error("An unexpected error occurred", "Please try again later"));
     }
+
+    @ExceptionHandler(TalentReadinessException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleTalentReadinessException(TalentReadinessException ex) {
+        log.error("Talent readiness error: {}", ex.getMessage(), ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponseDto.error(ex.getMessage(), "Talent readiness service error"));
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleUserNotFoundException(UserNotFoundException ex) {
+        log.error("User not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseDto.error(ex.getMessage(), "User not found"));
+    }
+
+    @ExceptionHandler(TalentRouteNotFoundException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleTalentRouteNotFoundException(TalentRouteNotFoundException ex) {
+        log.error("Talent route not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponseDto.error(ex.getMessage(), "Talent route not found"));
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<ApiResponseDto<Void>> handleValidationException(ValidationException ex) {
+        log.error("Validation error: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponseDto.error(ex.getMessage(), "Validation failed"));
+    }
 }
 

--- a/src/main/java/com/capstone/exception/TalentReadinessException.java
+++ b/src/main/java/com/capstone/exception/TalentReadinessException.java
@@ -1,0 +1,10 @@
+package com.capstone.exception;
+
+public class TalentReadinessException extends RuntimeException {
+    public TalentReadinessException(String message) {
+        super(message);
+    }
+    public TalentReadinessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/capstone/mapper/TalentReadinessMapper.java
+++ b/src/main/java/com/capstone/mapper/TalentReadinessMapper.java
@@ -1,0 +1,44 @@
+package com.capstone.mapper;
+
+import com.capstone.dto.response.ClusterDto;
+import com.capstone.dto.response.TalentReadinessDto;
+import com.capstone.model.ClusterSnapshot;
+import com.capstone.model.LearnerOnboarding;
+import com.capstone.model.UserSnapshot;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface TalentReadinessMapper {
+
+    @Mapping(source = "clusterId", target = "clusterId")
+    @Mapping(source = "name", target = "clusterName")
+    ClusterDto toClusterDto(ClusterSnapshot clusterSnapshot);
+
+    List<ClusterDto> toClusterDtoList(List<ClusterSnapshot> clusterSnapshots);
+
+    @Mapping(source = "onboarding.learner.userId", target = "learnerId")
+    @Mapping(source = "onboarding.learner", target = "learnerName", qualifiedByName = "getFullName")
+    @Mapping(source = "onboarding.learner.email", target = "learnerEmail")
+    @Mapping(source = "onboarding.talentRoute.talentRouteId", target = "talentRouteId")
+    @Mapping(source = "onboarding.talentRoute.routeName", target = "talentRouteName")
+    @Mapping(source = "onboarding.growthTrack.growthTrackId", target = "growthTrackId")
+    @Mapping(source = "onboarding.growthTrack.trackName", target = "growthTrackName")
+    @Mapping(target = "assessmentAverage", ignore = true)
+    @Mapping(target = "skillsCompleted", ignore = true)
+    @Mapping(target = "skillsTotal", ignore = true)
+    @Mapping(target = "skillsProgress", ignore = true)
+    @Mapping(target = "skillsProgressPercentage", ignore = true)
+    @Mapping(target = "clusters", ignore = true)
+    @Mapping(target = "readinessLevel", ignore = true)
+    @Mapping(target = "readinessScore", ignore = true)
+    TalentReadinessDto toBaseTalentReadinessDto(LearnerOnboarding onboarding);
+
+    @Named("getFullName")
+    default String getFullName(UserSnapshot userSnapshot) {
+        return userSnapshot.getFullName();
+    }
+}

--- a/src/main/java/com/capstone/model/ReadinessLevel.java
+++ b/src/main/java/com/capstone/model/ReadinessLevel.java
@@ -1,0 +1,7 @@
+package com.capstone.model;
+
+public enum ReadinessLevel {
+    NOT_READY,
+    MEDIUM,
+    HIGH
+}

--- a/src/main/java/com/capstone/model/UserSnapshot.java
+++ b/src/main/java/com/capstone/model/UserSnapshot.java
@@ -74,4 +74,16 @@ public class UserSnapshot {
         updatedAt = LocalDateTime.now();
     }
 
+    public String getFullName() {
+        if (firstName == null && lastName == null) {
+            return username;
+        }
+        if (firstName == null) {
+            return lastName;
+        }
+        if (lastName == null) {
+            return firstName;
+        }
+        return firstName + " " + lastName;
+    }
 }

--- a/src/main/java/com/capstone/repository/AssessmentSnapshotRepository.java
+++ b/src/main/java/com/capstone/repository/AssessmentSnapshotRepository.java
@@ -124,4 +124,18 @@ public interface AssessmentSnapshotRepository extends JpaRepository<AssessmentSn
                                        @Param("endDate") LocalDateTime endDate,
                                        @Param("threshold") Double threshold);
 
+    @Query("""
+             SELECT
+                 CONCAT(a.userSnapshot.userId, '_', tcm.growthTrack.growthTrackId) as compositeKey,
+                 AVG(a.score) as avgScore
+             FROM AssessmentSnapshot a
+             JOIN TrackCapsuleMapping tcm ON tcm.skillCapsule.capsuleId = a.capsuleSnapshot.capsuleId
+             WHERE a.userSnapshot.userId IN :userIds
+             AND tcm.growthTrack.growthTrackId IN :trackIds
+             GROUP BY a.userSnapshot.userId, tcm.growthTrack.growthTrackId
+             """)
+    List<Object[]> batchGetAverageScoresByUsersAndTracks(
+            @Param("userIds") List<UUID> userIds,
+            @Param("trackIds") List<UUID> trackIds
+    );
 }

--- a/src/main/java/com/capstone/repository/CapsuleClusterMappingRepository.java
+++ b/src/main/java/com/capstone/repository/CapsuleClusterMappingRepository.java
@@ -1,11 +1,36 @@
 package com.capstone.repository;
 
 import com.capstone.model.CapsuleClusterMapping;
+import com.capstone.model.ClusterSnapshot;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface CapsuleClusterMappingRepository extends JpaRepository<CapsuleClusterMapping, UUID> {
+
+    @Query("""
+             SELECT tcm.growthTrack.growthTrackId, ccm.theCluster
+             FROM TrackCapsuleMapping tcm
+             JOIN CapsuleClusterMapping ccm ON ccm.skillCapsule.capsuleId = tcm.skillCapsule.capsuleId
+             WHERE tcm.growthTrack.growthTrackId IN :trackIds
+             ORDER BY tcm.growthTrack.growthTrackId, ccm.theCluster.name
+             """)
+    List<Object[]> batchGetClustersByTrackIds(@Param("trackIds") List<UUID> trackIds);
+
+    @Query("SELECT DISTINCT ccm.theCluster FROM CapsuleClusterMapping ccm ORDER BY ccm.theCluster.name")
+    List<ClusterSnapshot> findAllUniqueClusters();
+
+    @Query("""
+                 SELECT DISTINCT lo.learner.userId
+                 FROM LearnerOnboarding lo
+                 JOIN TrackCapsuleMapping tcm ON tcm.growthTrack.growthTrackId = lo.growthTrack.growthTrackId
+                 JOIN CapsuleClusterMapping ccm ON ccm.skillCapsule.capsuleId = tcm.skillCapsule.capsuleId
+                 WHERE ccm.theCluster.clusterId IN :clusterIds
+                 """)
+    List<UUID> findLearnerIdsByClusterIds(@Param("clusterIds") List<UUID> clusterIds);
 }

--- a/src/main/java/com/capstone/repository/CompleteCapsuleRepository.java
+++ b/src/main/java/com/capstone/repository/CompleteCapsuleRepository.java
@@ -58,4 +58,19 @@ public interface CompleteCapsuleRepository extends JpaRepository<CompleteCapsule
              """, nativeQuery = true)
     List<Object[]> getYearlyCompletionCounts(@Param("startDate") LocalDateTime startDate,
                                              @Param("endDate") LocalDateTime endDate);
+
+    @Query("""
+             SELECT
+                 CONCAT(cc.userSnapshot.userId, '_', tcm.growthTrack.growthTrackId) as compositeKey,
+                 COUNT(DISTINCT cc.capsuleSnapshot.capsuleId) as completedCount
+             FROM CompleteCapsule cc
+             JOIN TrackCapsuleMapping tcm ON tcm.skillCapsule.capsuleId = cc.capsuleSnapshot.capsuleId
+             WHERE cc.userSnapshot.userId IN :userIds
+             AND tcm.growthTrack.growthTrackId IN :trackIds
+             GROUP BY cc.userSnapshot.userId, tcm.growthTrack.growthTrackId
+             """)
+    List<Object[]> batchGetCompletedCountsByUsersAndTracks(
+            @Param("userIds") List<UUID> userIds,
+            @Param("trackIds") List<UUID> trackIds
+    );
 }

--- a/src/main/java/com/capstone/repository/GrowthTrackCapsuleMappingRepository.java
+++ b/src/main/java/com/capstone/repository/GrowthTrackCapsuleMappingRepository.java
@@ -1,6 +1,5 @@
 package com.capstone.repository;
 
-import com.capstone.model.CapsuleSnapshot;
 import com.capstone.model.TrackCapsuleMapping;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,11 +11,11 @@ import java.util.UUID;
 
 @Repository
 public interface GrowthTrackCapsuleMappingRepository extends JpaRepository<TrackCapsuleMapping, UUID> {
-   // find all the capsules that belong to a growth track
     @Query("""
-    SELECT gtcm.skillCapsule
-    FROM TrackCapsuleMapping gtcm
-    WHERE gtcm.growthTrack.growthTrackId = :growthTrackId
-    """)
-    List<CapsuleSnapshot> findCapsulesByGrowthTrackId(@Param("growthTrackId") UUID growthTrackId);
+             SELECT tcm.growthTrack.growthTrackId, COUNT(tcm)
+             FROM TrackCapsuleMapping tcm
+             WHERE tcm.growthTrack.growthTrackId IN :trackIds
+             GROUP BY tcm.growthTrack.growthTrackId
+             """)
+    List<Object[]> batchGetCapsuleCountsByTrackIds(@Param("trackIds") List<UUID> trackIds);
 }

--- a/src/main/java/com/capstone/repository/LearnerOnboardingRepository.java
+++ b/src/main/java/com/capstone/repository/LearnerOnboardingRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
@@ -16,9 +17,82 @@ public interface LearnerOnboardingRepository extends JpaRepository<LearnerOnboar
     @Query("SELECT COUNT(lo) > 0 FROM LearnerOnboarding lo WHERE lo.learner.userId = :learnerId")
     boolean existsByLearnerId(@Param("learnerId") UUID learnerId);
 
-    @Query("SELECT lo FROM LearnerOnboarding lo " +
-            "LEFT JOIN FETCH lo.learner " +
-            "LEFT JOIN FETCH lo.talentRoute")
-    Page<LearnerOnboarding> findAllWithRelationships(Pageable pageable);
+    // Simple: Get all learners
+    @Query("""
+                  SELECT lo
+                  FROM LearnerOnboarding lo
+                  JOIN FETCH lo.learner l
+                  JOIN FETCH lo.talentRoute tr
+                  JOIN FETCH lo.growthTrack gt
+                  """)
+    Page<LearnerOnboarding> findAllWithDetails(Pageable pageable);
+
+    // Simple: Search by keyword
+    @Query("""
+                  SELECT lo
+                  FROM LearnerOnboarding lo
+                  JOIN FETCH lo.learner l
+                  JOIN FETCH lo.talentRoute tr
+                  JOIN FETCH lo.growthTrack gt
+                  WHERE LOWER(l.username) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                  OR LOWER(l.email) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                  OR LOWER(tr.routeName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                  """)
+    Page<LearnerOnboarding> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    // Simple: Filter by talent route
+    @Query("""
+                  SELECT lo
+                  FROM LearnerOnboarding lo
+                  JOIN FETCH lo.learner l
+                  JOIN FETCH lo.talentRoute tr
+                  JOIN FETCH lo.growthTrack gt
+                  WHERE tr.talentRouteId = :talentRouteId
+                  """)
+    Page<LearnerOnboarding> findByTalentRoute(@Param("talentRouteId") UUID talentRouteId, Pageable pageable);
+
+    // Simple: Filter by learner IDs
+    @Query("""
+                  SELECT lo
+                  FROM LearnerOnboarding lo
+                  JOIN FETCH lo.learner l
+                  JOIN FETCH lo.talentRoute tr
+                  JOIN FETCH lo.growthTrack gt
+                  WHERE l.userId IN :learnerIds
+                  """)
+    Page<LearnerOnboarding> findByLearnerIds(@Param("learnerIds") List<UUID> learnerIds, Pageable pageable);
+
+    @Query("""
+                  SELECT
+                      tr.talentRouteId,
+                      tr.routeName,
+                      COUNT(DISTINCT lo.learner.userId)
+                  FROM LearnerOnboarding lo
+                  JOIN lo.talentRoute tr
+                  GROUP BY tr.talentRouteId, tr.routeName
+                  """)
+    List<Object[]> getHeatmapAggregates();
+
+    @Query("""
+                  SELECT
+                      AVG(a.score),
+                      SUM(CASE WHEN a.score < 70 THEN 1 ELSE 0 END),
+                      SUM(CASE WHEN a.score >= 70 AND a.score < 85 THEN 1 ELSE 0 END),
+                      SUM(CASE WHEN a.score >= 85 THEN 1 ELSE 0 END)
+                  FROM LearnerOnboarding lo
+                  JOIN AssessmentSnapshot a ON a.userSnapshot.userId = lo.learner.userId
+                  JOIN TrackCapsuleMapping tcm ON tcm.skillCapsule.capsuleId = a.capsuleSnapshot.capsuleId
+                  WHERE lo.talentRoute.talentRouteId = :talentRouteId
+                  AND tcm.growthTrack.growthTrackId = lo.growthTrack.growthTrackId
+                  """)
+    List<Object[]> getRouteReadinessStats(@Param("talentRouteId") UUID talentRouteId);
+
+    @Query("""
+                  SELECT DISTINCT tr.talentRouteId, tr.routeName
+                  FROM LearnerOnboarding lo
+                  JOIN lo.talentRoute tr
+                  ORDER BY tr.routeName
+                  """)
+    List<Object[]> getAvailableTalentRoutes();
 
 }

--- a/src/main/java/com/capstone/service/TalentReadinessService.java
+++ b/src/main/java/com/capstone/service/TalentReadinessService.java
@@ -1,0 +1,27 @@
+package com.capstone.service;
+
+import com.capstone.dto.response.*;
+import com.capstone.model.ReadinessLevel;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface TalentReadinessService {
+
+    PaginatedResponseDto<TalentReadinessDto> getAllTalentReadiness(Pageable pageable);
+
+    PaginatedResponseDto<TalentReadinessDto> searchTalentReadiness(String keyword, Pageable pageable);
+
+    PaginatedResponseDto<TalentReadinessDto> getByTalentRoute(UUID talentRouteId, Pageable pageable);
+
+    PaginatedResponseDto<TalentReadinessDto> getByReadinessLevel(ReadinessLevel readinessLevel, Pageable pageable);
+
+    PaginatedResponseDto<TalentReadinessDto> getByClusters(List<UUID> clusterIds, Pageable pageable);
+
+    List<ClusterDto> getAvailableClusters();
+
+    List<TalentRouteDto> getAvailableTalentRoutes();
+
+    RoleReadinessHeatmapDto getRoleReadinessHeatmap();
+}

--- a/src/main/java/com/capstone/service/TalentReadinessServiceImpl.java
+++ b/src/main/java/com/capstone/service/TalentReadinessServiceImpl.java
@@ -1,0 +1,373 @@
+package com.capstone.service;
+
+import com.capstone.dto.response.*;
+import com.capstone.exception.TalentReadinessException;
+import com.capstone.model.*;
+import com.capstone.mapper.TalentReadinessMapper;
+import com.capstone.repository.*;
+import com.capstone.util.PaginationUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TalentReadinessServiceImpl implements TalentReadinessService {
+
+    private final LearnerOnboardingRepository learnerOnboardingRepository;
+    private final AssessmentSnapshotRepository assessmentSnapshotRepository;
+    private final CompleteCapsuleRepository completeCapsuleRepository;
+    private final GrowthTrackCapsuleMappingRepository trackCapsuleMappingRepository;
+    private final CapsuleClusterMappingRepository capsuleClusterMappingRepository;
+    private final TalentReadinessMapper mapper;
+
+    @Override
+    public PaginatedResponseDto<TalentReadinessDto> getAllTalentReadiness(Pageable pageable) {
+        try {
+            log.info("Getting all talent readiness - page: {}", pageable.getPageNumber());
+
+            Page<LearnerOnboarding> onboardings = learnerOnboardingRepository.findAllWithDetails(pageable);
+
+            return buildTalentReadinessResponse(onboardings);
+
+        } catch (Exception e) {
+            log.error("Error getting all talent readiness", e);
+            throw new TalentReadinessException("Error retrieving talent readiness data", e);
+        }
+    }
+
+    @Override
+    public PaginatedResponseDto<TalentReadinessDto> searchTalentReadiness(String keyword, Pageable pageable) {
+        try {
+            log.info("Searching talent readiness - keyword: {}, page: {}", keyword, pageable.getPageNumber());
+
+            Page<LearnerOnboarding> onboardings = learnerOnboardingRepository.searchByKeyword(keyword, pageable);
+
+            return buildTalentReadinessResponse(onboardings);
+
+        } catch (Exception e) {
+            log.error("Error searching talent readiness", e);
+            throw new TalentReadinessException("Error searching talent readiness data", e);
+        }
+    }
+
+    @Override
+    public PaginatedResponseDto<TalentReadinessDto> getByTalentRoute(UUID talentRouteId, Pageable pageable) {
+        try {
+            log.info("Getting talent readiness by route - talentRouteId: {}, page: {}", talentRouteId, pageable.getPageNumber());
+
+            Page<LearnerOnboarding> onboardings = learnerOnboardingRepository.findByTalentRoute(talentRouteId, pageable);
+
+            return buildTalentReadinessResponse(onboardings);
+
+        } catch (Exception e) {
+            log.error("Error getting talent readiness by route", e);
+            throw new TalentReadinessException("Error retrieving talent readiness by route", e);
+        }
+    }
+
+    @Override
+    public PaginatedResponseDto<TalentReadinessDto> getByReadinessLevel(ReadinessLevel readinessLevel, Pageable pageable) {
+        try {
+            log.info("Getting talent readiness by level - readinessLevel: {}, page: {}", readinessLevel, pageable.getPageNumber());
+
+            // Get all learners first, then filter by readiness level
+            // Note: This is less efficient but simple. For better performance, use native query with calculated field
+            Page<LearnerOnboarding> allOnboardings = learnerOnboardingRepository.findAllWithDetails(pageable);
+
+            Page<TalentReadinessDto> dtoPage = buildTalentReadinessDtoPage(allOnboardings);
+
+            // Filter by readiness level
+            List<TalentReadinessDto> filteredList = dtoPage.getContent().stream()
+                    .filter(dto -> dto.getReadinessLevel() == readinessLevel)
+                    .toList();
+
+            return buildFilteredPaginatedResponse(filteredList, dtoPage);
+
+        } catch (Exception e) {
+            log.error("Error getting talent readiness by level", e);
+            throw new TalentReadinessException("Error retrieving talent readiness by level", e);
+        }
+    }
+
+    @Override
+    public PaginatedResponseDto<TalentReadinessDto> getByClusters(List<UUID> clusterIds, Pageable pageable) {
+        try {
+            log.info("Getting talent readiness by clusters - clusterIds: {}, page: {}", clusterIds, pageable.getPageNumber());
+
+            // Step 1: Find learners who completed capsules with these clusters
+            // This is WHY we need learnerIds!
+            List<UUID> learnerIds = capsuleClusterMappingRepository.findLearnerIdsByClusterIds(clusterIds);
+
+            if (learnerIds.isEmpty()) {
+                return buildEmptyPaginatedResponse();
+            }
+
+            // Step 2: Get those specific learners
+            Page<LearnerOnboarding> onboardings = learnerOnboardingRepository.findByLearnerIds(learnerIds, pageable);
+
+            return buildTalentReadinessResponse(onboardings);
+
+        } catch (Exception e) {
+            log.error("Error getting talent readiness by clusters", e);
+            throw new TalentReadinessException("Error retrieving talent readiness by clusters", e);
+        }
+    }
+
+    @Override
+    public List<ClusterDto> getAvailableClusters() {
+        try {
+            log.info("Getting all available clusters");
+            List<ClusterSnapshot> clusters = capsuleClusterMappingRepository.findAllUniqueClusters();
+            return mapper.toClusterDtoList(clusters);
+        } catch (Exception e) {
+            log.error("Error getting available clusters", e);
+            throw new TalentReadinessException("Failed to retrieve clusters", e);
+        }
+    }
+
+    @Override
+    public List<TalentRouteDto> getAvailableTalentRoutes() {
+        try {
+            log.info("Getting all available talent routes");
+            List<Object[]> routes = learnerOnboardingRepository.getAvailableTalentRoutes();
+            return routes.stream()
+                    .map(row -> TalentRouteDto.builder()
+                            .talentRouteId((UUID) row[0])
+                            .routeName((String) row[1])
+                            .build())
+                    .toList();
+        } catch (Exception e) {
+            log.error("Error getting available talent routes", e);
+            throw new TalentReadinessException("Failed to retrieve talent routes", e);
+        }
+    }
+
+    @Override
+    public RoleReadinessHeatmapDto getRoleReadinessHeatmap() {
+        try {
+            log.info("Getting role readiness heatmap");
+
+            List<Object[]> aggregates = learnerOnboardingRepository.getHeatmapAggregates();
+
+            if (aggregates.isEmpty()) {
+                return RoleReadinessHeatmapDto.builder()
+                        .talentRoutes(Collections.emptyList())
+                        .build();
+            }
+
+            List<RoleReadinessDto> roles = aggregates.stream()
+                    .map(this::buildRoleReadinessFromAggregate)
+                    .toList();
+
+            return RoleReadinessHeatmapDto.builder()
+                    .talentRoutes(roles)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("Error getting role readiness heatmap", e);
+            throw new TalentReadinessException("Failed to retrieve heatmap data", e);
+        }
+    }
+
+    private PaginatedResponseDto<TalentReadinessDto> buildTalentReadinessResponse(Page<LearnerOnboarding> onboardings) {
+        if (onboardings.isEmpty()) {
+            return buildEmptyPaginatedResponse();
+        }
+
+        Page<TalentReadinessDto> dtoPage = buildTalentReadinessDtoPage(onboardings);
+        return PaginationUtil.toPaginatedResponse(dtoPage);
+    }
+
+    private Page<TalentReadinessDto> buildTalentReadinessDtoPage(Page<LearnerOnboarding> onboardings) {
+        // Batch fetch all data (4 queries total for N learners)
+        List<UUID> userIds = onboardings.getContent().stream()
+                .map(o -> o.getLearner().getUserId())
+                .toList();
+
+        List<UUID> trackIds = onboardings.getContent().stream()
+                .map(o -> o.getGrowthTrack().getGrowthTrackId())
+                .distinct()
+                .toList();
+
+        Map<String, Double> assessmentMap = batchGetAssessmentAverages(userIds, trackIds);
+        Map<String, Long> completedMap = batchGetCompletedCounts(userIds, trackIds);
+        Map<UUID, Long> totalMap = batchGetTotalCounts(trackIds);
+        Map<UUID, List<ClusterDto>> clusterMap = batchGetTrackClusters(trackIds);
+
+        // Build DTOs
+        return onboardings.map(o ->
+                buildTalentReadinessDto(o, assessmentMap, completedMap, totalMap, clusterMap));
+    }
+
+    private Map<String, Double> batchGetAssessmentAverages(List<UUID> userIds, List<UUID> trackIds) {
+        try {
+            List<Object[]> results = assessmentSnapshotRepository.batchGetAverageScoresByUsersAndTracks(userIds, trackIds);
+            return results.stream().collect(Collectors.toMap(
+                    r -> (String) r[0],
+                    r -> r[1] != null ? ((Number) r[1]).doubleValue() : 0.0
+            ));
+        } catch (Exception e) {
+            log.error("Error batch fetching assessment averages", e);
+            return new HashMap<>();
+        }
+    }
+
+    private Map<String, Long> batchGetCompletedCounts(List<UUID> userIds, List<UUID> trackIds) {
+        try {
+            List<Object[]> results = completeCapsuleRepository.batchGetCompletedCountsByUsersAndTracks(userIds, trackIds);
+            return results.stream().collect(Collectors.toMap(
+                    r -> (String) r[0],
+                    r -> r[1] != null ? ((Number) r[1]).longValue() : 0L
+            ));
+        } catch (Exception e) {
+            log.error("Error batch fetching completed counts", e);
+            return new HashMap<>();
+        }
+    }
+
+    private Map<UUID, Long> batchGetTotalCounts(List<UUID> trackIds) {
+        try {
+            List<Object[]> results = trackCapsuleMappingRepository.batchGetCapsuleCountsByTrackIds(trackIds);
+            return results.stream().collect(Collectors.toMap(
+                    r -> (UUID) r[0],
+                    r -> ((Number) r[1]).longValue()
+            ));
+        } catch (Exception e) {
+            log.error("Error batch fetching total counts", e);
+            return new HashMap<>();
+        }
+    }
+
+    private Map<UUID, List<ClusterDto>> batchGetTrackClusters(List<UUID> trackIds) {
+        try {
+            List<Object[]> results = capsuleClusterMappingRepository.batchGetClustersByTrackIds(trackIds);
+            return results.stream().collect(Collectors.groupingBy(
+                    r -> (UUID) r[0],
+                    Collectors.mapping(r -> mapper.toClusterDto((ClusterSnapshot) r[1]), Collectors.toList())
+            ));
+        } catch (Exception e) {
+            log.error("Error batch fetching track clusters", e);
+            return new HashMap<>();
+        }
+    }
+
+    private TalentReadinessDto buildTalentReadinessDto(
+            LearnerOnboarding onboarding,
+            Map<String, Double> assessmentMap,
+            Map<String, Long> completedMap,
+            Map<UUID, Long> totalMap,
+            Map<UUID, List<ClusterDto>> clusterMap) {
+
+        UUID userId = onboarding.getLearner().getUserId();
+        UUID trackId = onboarding.getGrowthTrack().getGrowthTrackId();
+        String compositeKey = userId.toString() + "_" + trackId.toString();
+
+        TalentReadinessDto dto = mapper.toBaseTalentReadinessDto(onboarding);
+
+        Double avgScore = assessmentMap.getOrDefault(compositeKey, 0.0);
+        Long completed = completedMap.getOrDefault(compositeKey, 0L);
+        Long total = totalMap.getOrDefault(trackId, 0L);
+
+        int skillsCompleted = completed.intValue();
+        int skillsTotal = total.intValue();
+        double progressPercentage = skillsTotal > 0 ? (skillsCompleted * 100.0 / skillsTotal) : 0.0;
+
+        dto.setAssessmentAverage(avgScore);
+        dto.setSkillsCompleted(skillsCompleted);
+        dto.setSkillsTotal(skillsTotal);
+        dto.setSkillsProgress(skillsCompleted + "/" + skillsTotal);
+        dto.setSkillsProgressPercentage(progressPercentage);
+        dto.setClusters(clusterMap.getOrDefault(trackId, Collections.emptyList()));
+        dto.setReadinessLevel(calculateReadinessLevel(avgScore, progressPercentage));
+        dto.setReadinessScore(calculateReadinessScore(avgScore, progressPercentage));
+
+        return dto;
+    }
+
+    private RoleReadinessDto buildRoleReadinessFromAggregate(Object[] aggregate) {
+        UUID talentRouteId = (UUID) aggregate[0];
+        String talentRouteName = (String) aggregate[1];
+        Integer learnerCount = ((Number) aggregate[2]).intValue();
+
+        List<Object[]> routeStats = learnerOnboardingRepository.getRouteReadinessStats(talentRouteId);
+
+        double avgScore = 0.0;
+        int notReady = 0;
+        int medium = 0;
+        int high = 0;
+
+        if (!routeStats.isEmpty() && routeStats.getFirst() != null) {
+            Object[] stats = routeStats.getFirst();
+            avgScore = stats[0] != null ? ((Number) stats[0]).doubleValue() : 0.0;
+            notReady = stats[1] != null ? ((Number) stats[1]).intValue() : 0;
+            medium = stats[2] != null ? ((Number) stats[2]).intValue() : 0;
+            high = stats[3] != null ? ((Number) stats[3]).intValue() : 0;
+        }
+
+        return RoleReadinessDto.builder()
+                .talentRouteId(talentRouteId)
+                .talentRouteName(talentRouteName)
+                .learnersCount(learnerCount)
+                .averageAssessmentScore(avgScore)
+                .readinessBreakdown(ReadinessBreakdownDto.builder()
+                        .notReady(notReady)
+                        .medium(medium)
+                        .high(high)
+                        .build())
+                .build();
+    }
+
+    private ReadinessLevel calculateReadinessLevel(Double avgScore, Double progressPercentage) {
+        if (avgScore < 70 || progressPercentage < 50) {
+            return ReadinessLevel.NOT_READY;
+        }
+        if (avgScore >= 85 && progressPercentage >= 80) {
+            return ReadinessLevel.HIGH;
+        }
+        return ReadinessLevel.MEDIUM;
+    }
+
+    private Double calculateReadinessScore(Double avgScore, Double progressPercentage) {
+        return (avgScore * 0.6) + (progressPercentage * 0.4);
+    }
+
+    private PaginatedResponseDto<TalentReadinessDto> buildEmptyPaginatedResponse() {
+        return PaginatedResponseDto.<TalentReadinessDto>builder()
+                .items(Collections.emptyList())
+                .pagination(PaginationMetadata.builder()
+                        .page(0)
+                        .size(0)
+                        .totalElements(0L)
+                        .totalPages(0)
+                        .hasNext(false)
+                        .hasPrevious(false)
+                        .build())
+                .build();
+    }
+
+    private PaginatedResponseDto<TalentReadinessDto> buildFilteredPaginatedResponse(
+            List<TalentReadinessDto> filteredList,
+            Page<TalentReadinessDto> originalPage) {
+
+        return PaginatedResponseDto.<TalentReadinessDto>builder()
+                .items(filteredList)
+                .pagination(PaginationMetadata.builder()
+                        .page(originalPage.getNumber())
+                        .size(filteredList.size())
+                        .totalElements(originalPage.getTotalElements())
+                        .totalPages(originalPage.getTotalPages())
+                        .hasNext(originalPage.hasNext())
+                        .hasPrevious(originalPage.hasPrevious())
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
# 🚀 Pull Request: Talent Readiness Analytics Implementation

## 🎫 Jira Ticket  
### 🔗[SPRINT-3/VER-196:Implement Talent Readiness Analytics](https://amali-tech.atlassian.net/browse/VER-196)

## ✅  Summary
Implemented talent readiness analytics with separate, focused endpoints for filtering learners by various criteria. This refactor fixes PostgreSQL UUID parameter binding issues by eliminating complex conditional queries in favor of dedicated query methods per filter type.

## 🎯 Core Features:
- Talent readiness analytics with multiple filtering options                                                                                   
- Separate REST endpoints for each filter type (search, talent route, readiness level, clusters)                                               
- Heatmap visualization showing readiness breakdown per talent route

## 🚧 Next Task
- Security Configuration with Role-Based-Acces-Control